### PR TITLE
Fix check for existing tag in Dawn build

### DIFF
--- a/.github/workflows/dawn-check.yaml
+++ b/.github/workflows/dawn-check.yaml
@@ -89,11 +89,15 @@ jobs:
         id: release_check
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
+
+          echo "Checking for release: $TAG"
+          gh release view "$TAG"
+
           if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release '$TAG' already exists. Skipping upload."
+            echo "Release '$TAG' already exists. Skipping build."
             echo "needs_build=false" >> $GITHUB_OUTPUT
           else
-            echo "Uploading to release: $TAG"
+            echo "Starting build for release: $TAG"
             echo "needs_build=true" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/dawn-check.yaml
+++ b/.github/workflows/dawn-check.yaml
@@ -46,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       needs_build: ${{ steps.release_check.outputs.needs_build }}
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -89,10 +91,6 @@ jobs:
         id: release_check
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
-
-          echo "Checking for release: $TAG"
-          gh release view "$TAG"
-
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release '$TAG' already exists. Skipping build."
             echo "needs_build=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION

## Description

The check for whether there was an existing release with a given tag was broken. This fixes it. A full build will not be initiated for a version of Dawn that has already been released.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
