### PR TITLE
Fix windows info in archive bundles

### DIFF
--- a/Dawn/archive_builder.py
+++ b/Dawn/archive_builder.py
@@ -31,7 +31,7 @@ def write_target_manifest(
         "libraryPath": (target_dir / "lib").as_posix(),
         "includePath": (target_dir / "include").as_posix(),
         "supportedTriples": target_config.triples(),
-        "libraryName": "libwebgpu_dawn.lib"
+        "libraryName": "webgpu_dawn.lib"
         if target_config.os.is_windows()
         else "libwebgpu_dawn.a",
     }
@@ -63,10 +63,15 @@ def write_bundle_manifest(version: str) -> None:
     archive_dir.mkdir(exist_ok=True, parents=True)
     archive_manifest_file = archive_dir / "info.json"
 
+    def add_lib_prefix(library_name: str) -> str:
+        if not library_name.startswith("lib"):
+            return "lib" + library_name
+        return library_name
+
     target_manifests = [
         {
             "path": (
-                pathlib.Path(manifest["targetName"]) / manifest["libraryName"]
+                pathlib.Path(manifest["targetName"]) / add_lib_prefix(manifest["libraryName"])
             ).as_posix(),
             "staticLibraryMetadata": {"headerPaths": ["include"]},
             "supportedTriples": manifest["supportedTriples"],
@@ -144,6 +149,14 @@ def create_artifact_bundle(
         library_path = manifest["libraryPath"]
         target_dir = archive_dir / manifest["targetName"]
         shutil.copytree(library_path, target_dir)
+        
+        # Rename library to have "lib" prefix if needed
+        library_name = manifest["libraryName"]
+        if not library_name.startswith("lib"):
+            old_path = target_dir / library_name
+            new_path = target_dir / ("lib" + library_name)
+            old_path.rename(new_path)
+                
 
     # Copy the dawn.json file to the archive directory
     shutil.copy2(dawn_json, archive_dir / "dawn.json")

--- a/Dawn/ci_targets.py
+++ b/Dawn/ci_targets.py
@@ -61,6 +61,7 @@ def ci_target(name: str, config: str = "release") -> TargetConfig:
             return TargetConfig(
                 os=OS.WINDOWS,
                 arch=[Arch.X86_64],
+                sdk="msvc",
                 config=config,
                 build_tool="Visual Studio 17 2022",
             )


### PR DESCRIPTION


## Description

The triple for Windows was wrong in the Dawn archive bundle, plus Swift complains if the library does not start with "lib"

## Motivation and Context

Makes the Dawn archive bundle that is built nightly usable from Swift on Windows.

## How Has This Been Tested?

Inspected by hand

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
