### PR TITLE
Add the required DirectX compiler for Windows

### DIFF
--- a/Dawn/CMakeLists.txt
+++ b/Dawn/CMakeLists.txt
@@ -12,6 +12,7 @@ set(TINT_BUILD_CMD_TOOLS OFF CACHE BOOL "Disable Tint command line tools")
 set(DAWN_ENABLE_INSTALL ON CACHE BOOL "Enable Dawn install target")
 set(DAWN_FETCH_DEPENDENCIES ON CACHE BOOL "Fetch Dawn dependencies")
 set(DAWN_BUILD_MONOLITHIC_LIBRARY STATIC CACHE STRING "Build Dawn as static monolithic library")
+set(DAWN_USE_BUILT_DXC ON CACHE BOOL "Use built DXC")
 
 # Add Dawn from source
 add_subdirectory(dawn_source)

--- a/Dawn/archive_builder.py
+++ b/Dawn/archive_builder.py
@@ -35,6 +35,10 @@ def write_target_manifest(
         if target_config.os.is_windows()
         else "libwebgpu_dawn.a",
     }
+    
+    if target_config.os.is_windows():
+        manifest["binPath"] = (target_dir / "bin").as_posix()
+    
     manifest_file.write_text(json.dumps(manifest, indent=2))
 
 
@@ -81,6 +85,34 @@ def write_bundle_manifest(version: str) -> None:
                 "version": version,
                 "type": "staticLibrary",
                 "variants": target_manifests,
+            },
+            "dxcompiler": {
+                "type": "staticLibrary",
+                "version": "1.0.0",
+                "variants": [
+                    {
+                        "path": "windows_arm64_release/bin/dxcompiler.dll",
+                        "supportedTriples": ["arm64-unknown-windows-msvc"]
+                    },
+                    {
+                        "path": "windows_x86_64_release/bin/dxcompiler.dll",
+                        "supportedTriples": ["x86_64-unknown-windows-msvc"]
+                    },
+                ]
+            },
+            "dxil": {
+                "type": "staticLibrary",
+                "version": "1.0.0",
+                "variants": [
+                    {
+                        "path": "windows_arm64_release/bin/dxil.dll",
+                        "supportedTriples": ["arm64-unknown-windows-msvc"]
+                    },
+                    {
+                        "path": "windows_x86_64_release/bin/dxil.dll",
+                        "supportedTriples": ["x86_64-unknown-windows-msvc"]
+                    }
+                ]
             }
         },
     }
@@ -144,6 +176,13 @@ def create_artifact_bundle(
         library_path = manifest["libraryPath"]
         target_dir = archive_dir / manifest["targetName"]
         shutil.copytree(library_path, target_dir)
+        
+        # Copy the bin directory if it exists (Windows targets)
+        if "binPath" in manifest:
+            bin_path = manifest["binPath"]
+            bin_target_dir = target_dir / "bin"
+            shutil.copytree(bin_path, bin_target_dir)
+        
         
     # Copy the dawn.json file to the archive directory
     shutil.copy2(dawn_json, archive_dir / "dawn.json")

--- a/Dawn/dawn_builder.py
+++ b/Dawn/dawn_builder.py
@@ -315,3 +315,13 @@ def build_dawn(
     except subprocess.CalledProcessError as e:
         _subprocess_exception_message(e)
         raise CMakeError
+
+    # Copy DirectX support files to output_dir/bin (Windows only)
+    if target_config.os.is_windows():
+        source_dir = build_dir / config
+        dest_dir = output_dir / "bin"
+        if source_dir.exists():
+            dest_dir.mkdir(exist_ok=True, parents=True)
+            for item in source_dir.iterdir():
+                if item.is_file():
+                    shutil.copy2(item, dest_dir / item.name)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

When building the Dawn archive bundle, include the libraries need on Windows for DirectX

## Related Issue

Our Dawn artifact bundle contains a static Dawn library, but that still needs some DirectX DLLs on Windows.

## Motivation and Context

We would like our examples to run on Windows

## How Has This Been Tested?

Manual testing


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
