### PR TITLE
add optional nextInChain parameter to init() for chained structs

### DIFF
--- a/Sources/GenerateDawnBindings/DawnStructure+Wrappers.swift
+++ b/Sources/GenerateDawnBindings/DawnStructure+Wrappers.swift
@@ -146,7 +146,7 @@ extension DawnStructure: DawnType {
 					body: CodeBlockSyntax(
 						statements: memberAssignments
 					)
-				).formatted()
+				).formatted(using: TabFormat(initialIndentation: .tabs(0)))
 			)!
 		} catch {
 			fatalError("Failed to get members for creating init: \(error)")

--- a/Tests/CodeGenerationTests/GenerateWrappersTest.swift
+++ b/Tests/CodeGenerationTests/GenerateWrappersTest.swift
@@ -521,7 +521,11 @@ struct TestTypeDescriptor: TypeDescriptor {
 		let combined = declarations.map { $0.formatted().description }.joined(separator: "\n")
 
 		// Verify init signature excludes entryCount parameter
-		#expect(combined.contains("public init(label: String? = nil, entries: [GPUBindGroupLayoutEntry] = [])"))
+		#expect(
+			combined.contains(
+				"public init(label: String? = nil, entries: [GPUBindGroupLayoutEntry] = [], nextInChain: (any GPUChainedStruct)? = nil)"
+			)
+		)
 		#expect(!combined.contains("entryCount: Int"))
 
 		// Verify stored properties exclude entryCount


### PR DESCRIPTION
## Description

Wrapped structs that support structure chaining (chained and root) now accept an optional `nextInChain` argument in their generated `init()`, so the chain can be set at construction time instead of only via the property afterward.

### Changes

- **GenerateDawnBindings:** In `DawnStructure+Wrappers.swift`, `initDecl(data:)` was updated so that when `extensibilityType != .none` it adds:
  - Parameter: `nextInChain: (any GPUChainedStruct)? = nil`
  - Assignment: `self.nextInChain = nextInChain`

### Usage
```swift
// Before: set chain after init
var opts = GPURequestAdapterOptions(powerPreference: .highPerformance)
opts.nextInChain = luidOptions

// After: pass chain in init (optional)
let opts = GPURequestAdapterOptions(powerPreference: .highPerformance, nextInChain: luidOptions)
```

Scope: Applies to all generated wrapper structs that already have a nextInChain property (ChainedStruct and RootStruct). Existing call sites remain valid because the new parameter is optional and defaults to nil.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
