### PR TITLE
Remove array size members from generated structs

### DIFF
--- a/Demos/DemoUtils/Demo.swift
+++ b/Demos/DemoUtils/Demo.swift
@@ -66,9 +66,7 @@ public func runDemo<Provider: DemoProvider>(
 	)
 
 	deviceDescriptor.nextInChain = DawnTogglesDescriptor(
-		enabledToggleCount: 1,
 		enabledToggles: ["disable_symbol_renaming"],
-		disabledToggleCount: 0,
 		disabledToggles: []
 	)
 

--- a/Demos/GameOfLife/GameOfLife.swift
+++ b/Demos/GameOfLife/GameOfLife.swift
@@ -129,7 +129,6 @@ struct GameOfLifeDemo: DemoProvider {
 		let bindGroupLayout = device.createBindGroupLayout(
 			descriptor: GPUBindGroupLayoutDescriptor(
 				label: "Cell Bind Group Layout",
-				entryCount: 3,
 				entries: [
 					GPUBindGroupLayoutEntry(
 						binding: 0,
@@ -156,7 +155,6 @@ struct GameOfLifeDemo: DemoProvider {
 				descriptor: GPUBindGroupDescriptor(
 					label: "Cell renderer bind group A",
 					layout: bindGroupLayout,
-					entryCount: 3,
 					entries: [
 						GPUBindGroupEntry(binding: 0, buffer: uniformBuffer!),
 						GPUBindGroupEntry(binding: 1, buffer: cellStateStorage[0]),
@@ -168,7 +166,6 @@ struct GameOfLifeDemo: DemoProvider {
 				descriptor: GPUBindGroupDescriptor(
 					label: "Cell renderer bind group B",
 					layout: bindGroupLayout,
-					entryCount: 3,
 					entries: [
 						GPUBindGroupEntry(binding: 0, buffer: uniformBuffer!),
 						GPUBindGroupEntry(binding: 1, buffer: cellStateStorage[1]),
@@ -182,7 +179,6 @@ struct GameOfLifeDemo: DemoProvider {
 		let pipelineLayout = device.createPipelineLayout(
 			descriptor: GPUPipelineLayoutDescriptor(
 				label: "Cell Pipeline Layout",
-				bindGroupLayoutCount: 1,
 				bindGroupLayouts: [bindGroupLayout]
 			)
 		)
@@ -195,11 +191,9 @@ struct GameOfLifeDemo: DemoProvider {
 				vertex: GPUVertexState(
 					module: cellShaderModule,
 					entryPoint: "vertexMain",
-					bufferCount: 1,
 					buffers: [
 						GPUVertexBufferLayout(
 							arrayStride: 8,
-							attributeCount: 1,
 							attributes: [
 								GPUVertexAttribute(format: .float32x2, offset: 0, shaderLocation: 0)
 							]
@@ -220,7 +214,6 @@ struct GameOfLifeDemo: DemoProvider {
 				fragment: GPUFragmentState(
 					module: cellShaderModule,
 					entryPoint: "fragmentMain",
-					targetCount: 1,
 					targets: [GPUColorTargetState(format: format)]
 				)
 			)
@@ -244,7 +237,6 @@ struct GameOfLifeDemo: DemoProvider {
 		let pass = encoder.beginRenderPass(
 			descriptor: GPURenderPassDescriptor(
 				label: "render pass",
-				colorAttachmentCount: 1,
 				colorAttachments: [
 					GPURenderPassColorAttachment(
 						view: destTexture.createView(),

--- a/Sources/GenerateDawnBindings/DawnEnum+Wrappers.swift
+++ b/Sources/GenerateDawnBindings/DawnEnum+Wrappers.swift
@@ -56,16 +56,10 @@ extension DawnEnum {
 			return expression ?? ""
 		}
 		let optional = optional ?? false
-		// Unpack an array of values.
-		let count: ExprSyntax = optional ? "\(raw: identifier)?.count ?? 0" : "\(raw: identifier).count"
-		guard case .name(let lengthName) = length else {
-			fatalError("Unimplemented unwrapValueOfType for type \(type.raw) with length \(length!)")
-		}
+		// Unpack an array of values. Count extraction is done at the top level via generateArraySizeExtractions().
 		return
 			"""
-			withWGPUArrayPointer(\(raw: identifier)) { (_\(raw: identifier): UnsafePointer<WGPU\(raw: type.CamelCase)>\(raw: optional ? "?" : "")) in
-				let \(raw: lengthName.camelCase) = \(count)
-				let \(raw: identifier) = _\(raw: identifier)
+			withWGPUArrayPointer(\(raw: identifier)) { (\(raw: identifier): UnsafePointer<WGPU\(raw: type.CamelCase)>\(raw: optional ? "?" : "")) in
 				return \(expression ?? "", format: TabFormat(initialIndentation: .tabs(1)))
 			}
 			"""

--- a/Sources/GenerateDawnBindings/DawnFunctionArgument+Wrappers.swift
+++ b/Sources/GenerateDawnBindings/DawnFunctionArgument+Wrappers.swift
@@ -7,7 +7,7 @@
 
 import DawnData
 
-extension DawnFunctionArgument: TypeDescriptor {
+extension DawnFunctionArgument: NamedTypeDescriptor {
 	var isInOut: Bool {
 		return annotation == "void*" || annotation == "*"
 	}

--- a/Sources/GenerateDawnBindings/DawnStructure+Wrappers.swift
+++ b/Sources/GenerateDawnBindings/DawnStructure+Wrappers.swift
@@ -107,9 +107,8 @@ extension DawnStructure: DawnType {
 	}
 
 	func getMembers(data: DawnData) throws -> [(name: String, swiftType: String, defaultValue: String?)] {
-		return
-			try members
-			.map { try $0.getMemberInfo(data: data) }
+		let filteredMembers = members.filter { !isArraySizeItem($0, allItems: members) }
+		return try filteredMembers.map { try $0.getMemberInfo(data: data) }
 	}
 
 	func isSimpleWGPUStruct(_ member: DawnStructureMember, data: DawnData) -> Bool {
@@ -213,19 +212,29 @@ extension DawnStructure: DawnType {
 		}
 
 		// Unwrap the members of the WGPU struct before calling the lambda.
+		// Filter out size parameters since they are derived from array counts.
+		let membersToUnwrap = members.filter { !isArraySizeItem($0, allItems: members) }
 		let unwrappedMemberExpr = unwrapMembers(
-			members,
+			membersToUnwrap,
 			wgpuStructIdentifier: "wgpuStruct",
 			data: data,
 			expression: lambdaCallExpr
 		)
+
+		// Generate array size extractions at the start of the function body.
+		let arraySizeExtractions = generateArraySizeExtractions(items: members, data: data)
+
+		let body = CodeBlockItemListSyntax {
+			arraySizeExtractions
+			"return \(unwrappedMemberExpr)"
+		}
 
 		return DeclSyntax(
 			"""
 			public func withWGPUStruct<R>(
 				_ lambda: (inout \(raw: cStructName)) -> R
 			) -> R {
-				\(unwrappedMemberExpr)
+				\(body, format: TabFormat(initialIndentation: .tabs(0)))
 			}
 			"""
 		)
@@ -235,7 +244,7 @@ extension DawnStructure: DawnType {
 	/// the WGPU struct's data.
 	func initWithWGPUStructMethod(cStructName: String, data: DawnData) -> DeclSyntax {
 		let memberAssignments: CodeBlockItemListSyntax = CodeBlockItemListSyntax {
-			for member in members {
+			for member in members where !isArraySizeItem(member, allItems: members) {
 				if member.type.raw == "string view" {
 					"self.\(raw: member.name.camelCase) = String(wgpuStringView: wgpuStruct.\(raw: member.name.camelCase))!"
 				} else if member.isWrappedType(data: data) {
@@ -300,7 +309,8 @@ extension DawnStructure: DawnType {
 			structProtocol = "\(structProtocol), GPUStructWrappable"
 		}
 
-		let memberDecls = try members.flatMap { try $0.declarations(data: data) }
+		let membersForProperties = members.filter { !isArraySizeItem($0, allItems: members) }
+		let memberDecls = try membersForProperties.flatMap { try $0.declarations(data: data) }
 
 		let chainMemberDecl: DeclSyntax? =
 			extensibilityType == .none ? nil : "public var nextInChain: (any GPUChainedStruct)? = nil"
@@ -349,17 +359,13 @@ extension DawnStructure: DawnType {
 				if case .int = length! {
 					fatalError("Unimplemented unwrapValueOfType for type \(type.raw) with length \(length!)")
 				}
-				if case .name(let lengthName) = length! {
-					let count: ExprSyntax = optional ? "\(raw: identifier)?.count ?? 0" : "\(raw: identifier).count"
-					return
-						"""
-						withWGPUArrayPointer(\(raw: identifier)) { _\(raw: identifier) in
-							let \(raw: lengthName.camelCase) = \(count)
-							let \(raw: identifier) = _\(raw: identifier)
-							return \(expression ?? "", format: TabFormat(initialIndentation: .tabs(1)))
-						}
-						"""
-				}
+				// Count extraction is now done at the top level via generateArraySizeExtractions()
+				return
+					"""
+					withWGPUArrayPointer(\(raw: identifier)) { \(raw: identifier) in
+						return \(expression ?? "", format: TabFormat(initialIndentation: .tabs(1)))
+					}
+					"""
 			}
 			// Even though this type of structure is normally unwrapped, we still need to
 			// "unwrap" it into a pointer that we can pass to the WGPU API.

--- a/Sources/GenerateDawnBindings/DawnStructureMember+Wrappers.swift
+++ b/Sources/GenerateDawnBindings/DawnStructureMember+Wrappers.swift
@@ -8,7 +8,7 @@
 import DawnData
 import SwiftSyntax
 
-extension DawnStructureMember: TypeDescriptor {
+extension DawnStructureMember: NamedTypeDescriptor {
 
 	func getMemberInfo(data: DawnData) throws -> (name: String, swiftType: String, defaultValue: String?) {
 		var defaultString: String? = nil

--- a/Tests/CodeGenerationTests/GenerateWrappersTest.swift
+++ b/Tests/CodeGenerationTests/GenerateWrappersTest.swift
@@ -208,7 +208,7 @@ struct TestTypeDescriptor: TypeDescriptor {
 				public func withWGPUStruct<R>(
 					_ lambda: (inout WGPUAdapterInfo) -> R
 				) -> R {
-					vendor.withWGPUStruct { vendor in
+					return vendor.withWGPUStruct { vendor in
 						architecture.withWGPUStruct { architecture in
 							device.withWGPUStruct { device in
 								description.withWGPUStruct { description in
@@ -493,6 +493,71 @@ struct TestTypeDescriptor: TypeDescriptor {
 		#expect(combinedDescription.contains("extension DawnDrmFormatProperties: GPUSimpleStruct"))
 	}
 
+	@Test("Struct init excludes array size parameters")
+	func testStructInitExcludesArraySizeParameter() {
+		let data = try? JSONDecoder().decode(DawnData.self, from: structWithArrayDawnData.data(using: .utf8)!)
+		guard let data = data else {
+			Issue.record("Failed to decode data")
+			return
+		}
+
+		let bindGroupLayoutDescriptor = data.data[Name("bind group layout descriptor")]
+		guard let bindGroupLayoutDescriptor = bindGroupLayoutDescriptor else {
+			Issue.record("Failed to get bind group layout descriptor")
+			return
+		}
+
+		guard case .structure(let structure) = bindGroupLayoutDescriptor else {
+			Issue.record("Bind group layout descriptor is not a structure")
+			return
+		}
+
+		let declarations = try? structure.declarations(name: Name("bind group layout descriptor"), needsWrap: false, data: data)
+		guard let declarations = declarations else {
+			Issue.record("Failed to get declarations")
+			return
+		}
+		let combined = declarations.map { $0.formatted().description }.joined(separator: "\n")
+
+		// Verify init signature excludes entryCount parameter
+		#expect(combined.contains("public init(label: String? = nil, entries: [GPUBindGroupLayoutEntry] = [])"))
+		#expect(!combined.contains("entryCount: Int"))
+
+		// Verify stored properties exclude entryCount
+		#expect(combined.contains("public var entries: [GPUBindGroupLayoutEntry]"))
+		#expect(!combined.contains("public var entryCount"))
+	}
+
+	@Test("Struct withWGPUStruct derives count from array")
+	func testStructWithWGPUStructDerivesCount() {
+		let data = try? JSONDecoder().decode(DawnData.self, from: structWithArrayDawnData.data(using: .utf8)!)
+		guard let data = data else {
+			Issue.record("Failed to decode data")
+			return
+		}
+
+		let bindGroupLayoutDescriptor = data.data[Name("bind group layout descriptor")]
+		guard let bindGroupLayoutDescriptor = bindGroupLayoutDescriptor else {
+			Issue.record("Failed to get bind group layout descriptor")
+			return
+		}
+
+		guard case .structure(let structure) = bindGroupLayoutDescriptor else {
+			Issue.record("Bind group layout descriptor is not a structure")
+			return
+		}
+
+		let declarations = try? structure.declarations(name: Name("bind group layout descriptor"), needsWrap: false, data: data)
+		guard let declarations = declarations else {
+			Issue.record("Failed to get declarations")
+			return
+		}
+		let combined = declarations.map { $0.formatted().description }.joined(separator: "\n")
+
+		// Verify withWGPUStruct extracts count from array
+		#expect(combined.contains("let entryCount = entries.count"))
+	}
+
 }
 
 let deviceDawnData = """
@@ -634,6 +699,39 @@ let dawnPrefixedDawnData = """
 		"uint32_t": {
 			"category": "native",
 			"wasm type": "i"
+		}
+	}
+	"""
+
+let structWithArrayDawnData = """
+	{
+		"bind group layout descriptor": {
+			"category": "structure",
+			"extensible": "in",
+			"members": [
+				{"name": "label", "type": "string view", "optional": true},
+				{"name": "entry count", "type": "size_t"},
+				{"name": "entries", "type": "bind group layout entry", "annotation": "const*", "length": "entry count"}
+			]
+		},
+		"bind group layout entry": {
+			"category": "structure",
+			"members": [
+				{"name": "binding", "type": "uint32_t"}
+			]
+		},
+		"string view": {
+			"category": "structure",
+			"members": [
+				{"name": "data", "type": "char", "annotation": "const*", "optional": true},
+				{"name": "length", "type": "size_t", "default": "strlen"}
+			]
+		},
+		"size_t": {
+			"category": "native"
+		},
+		"uint32_t": {
+			"category": "native"
 		}
 	}
 	"""

--- a/Tests/DawnTests/WebGPUPipelineTests.swift
+++ b/Tests/DawnTests/WebGPUPipelineTests.swift
@@ -62,7 +62,6 @@ extension GPUDevice {
 				vertex: GPUVertexState(
 					module: shaderModule,
 					entryPoint: vertexEntryPoint,
-					bufferCount: 0,
 					buffers: []
 				),
 				primitive: GPUPrimitiveState(
@@ -79,7 +78,6 @@ extension GPUDevice {
 				fragment: GPUFragmentState(
 					module: shaderModule,
 					entryPoint: fragmentEntryPoint,
-					targetCount: 1,
 					targets: [GPUColorTargetState(format: format)]
 				)
 			)
@@ -132,7 +130,6 @@ struct WebGPUPipelineTests {
 
 		let renderPassDescriptor = GPURenderPassDescriptor(
 			label: "Test Render Pass",
-			colorAttachmentCount: 1,
 			colorAttachments: [
 				GPURenderPassColorAttachment(
 					view: textureView,
@@ -214,7 +211,6 @@ struct WebGPUPipelineTests {
 		let bindGroupLayout = device.createBindGroupLayout(
 			descriptor: GPUBindGroupLayoutDescriptor(
 				label: "Compute Bind Group Layout",
-				entryCount: 1,
 				entries: [
 					GPUBindGroupLayoutEntry(
 						binding: 0,
@@ -229,7 +225,6 @@ struct WebGPUPipelineTests {
 		let pipelineLayout = device.createPipelineLayout(
 			descriptor: GPUPipelineLayoutDescriptor(
 				label: "Compute Pipeline Layout",
-				bindGroupLayoutCount: 1,
 				bindGroupLayouts: [bindGroupLayout]
 			)
 		)
@@ -251,7 +246,6 @@ struct WebGPUPipelineTests {
 			descriptor: GPUBindGroupDescriptor(
 				label: "Compute Bind Group",
 				layout: bindGroupLayout,
-				entryCount: 1,
 				entries: [
 					GPUBindGroupEntry(binding: 0, buffer: storageBuffer)
 				]


### PR DESCRIPTION
## Description
In #54, we removed size parameters from method calls. This applies the same technique to structs.

- Move needed functions into TypeDescriptors.swift, and change them to operate on a `NamedTypeDescriptor` protocol that both `DawnStructureMember` and `DawnFunctionArgument` now conform to.
- Update demo and test code to remove the now-unnecessary arguments to various struct init calls.

## How Has This Been Tested?
GameOfLife demo runs as before.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
