### PR TITLE
Fix naming of artifact bundles for platforms

### DIFF
--- a/Dawn/archive_builder.py
+++ b/Dawn/archive_builder.py
@@ -231,7 +231,7 @@ def create_platform_artifact_bundle(
         Path to the created zip archive (without the .zip extension appended by
         shutil.make_archive; the actual file is at the returned path + ".zip")
     """
-    bundle_name = f"{base_name}_{platform}.artifactbundle"
+    bundle_name = f"{base_name}_{platform.value}.artifactbundle"
     bundle_dir = dist_directory() / bundle_name
 
     # Remove any existing bundle directory


### PR DESCRIPTION
## Description

Our releases of Dawn included the string PlatformGroup which came from the enum. Fixed that.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
