### PR TITLE
Allow overriding Dawn artifact URL via environment variable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,11 +24,19 @@ let useAddressSanitizer: Bool = ProcessInfo.processInfo.environment["USE_ADDRESS
 let usePDBDebugInfo: Bool = false
 #endif
 
+let dawnArtifactURL: String? = ProcessInfo.processInfo.environment["DAWN_ARTIFACT_URL"]
+
 let dawnTarget: Target = {
 	if swanLocalDawn {
 		return .binaryTarget(
 			name: "DawnLib",
 			path: "Dawn/dist/dawn_webgpu.artifactbundle"
+		)
+	} else if let dawnArtifactURL {
+		return .binaryTarget(
+			name: "DawnLib",
+			url: dawnArtifactURL,
+			checksum: ProcessInfo.processInfo.environment["DAWN_ARTIFACT_CHECKSUM"] ?? ""
 		)
 	} else {
 		return .binaryTarget(


### PR DESCRIPTION

## Description

Add support for DAWN_ARTIFACT_URL and DAWN_ARTIFACT_CHECKSUM environment variables to specify a custom Dawn binary artifact, useful for testing pre-release builds or using alternative artifact sources.

## Motivation and Context

Some users of Swan will need to have tighter control over the dependencies.

## How Has This Been Tested?

Manual testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
