### PR TITLE
remove manual dependency on swift-testing

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "be1f1c0cf6d70457e94021b1fe15aaf7b8b2150e3c838a9178f16886a2853efe",
+  "originHash" : "e6b0619f4be96d9811541259f006ca5deaa1e111dab41e380b174b87f794ab61",
   "pins" : [
     {
       "identity" : "javascriptkit",
@@ -53,15 +53,6 @@
       "state" : {
         "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
         "version" : "602.0.0"
-      }
-    },
-    {
-      "identity" : "swift-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-testing.git",
-      "state" : {
-        "revision" : "5ee435b15ad40ec1f644b5eb9d247f263ccd2170",
-        "version" : "6.2.4"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -109,15 +109,7 @@ let package = Package(
 		.package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0"),
 		.package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0"),
 		.package(url: "https://github.com/swiftlang/swift-format.git", from: "602.0.0"),
-	]
-		+ (buildMacOS14
-			? []
-			: [
-				.package(
-					url: "https://github.com/swiftlang/swift-testing.git",
-					from: "6.2.4"
-				)
-			]),
+	],
 	targets: isWasmBuild
 		? [
 			.target(
@@ -333,7 +325,6 @@ let package = Package(
 						dependencies: [
 							"GenerateDawnBindings",
 							"GenerateDawnAPINotes",
-							.product(name: "Testing", package: "swift-testing"),
 						],
 						swiftSettings: swiftSettings,
 						linkerSettings: asanLinkerSettings
@@ -342,7 +333,6 @@ let package = Package(
 						name: "DawnTests",
 						dependencies: [
 							"WebGPU",
-							.product(name: "Testing", package: "swift-testing"),
 						],
 						swiftSettings: swiftSettings,
 						linkerSettings: asanLinkerSettings + [


### PR DESCRIPTION
We do not need to manually depend on a swift testing from github. 
It comes with the toolchain! 

In fact, the manual dependency is creating problems when switching to swift `main-snapshot-2026-04-01`.
Removing it makes swan build (and test) again with that snapshot.
