### PR TITLE
Fix resource leak

### DIFF
--- a/Sources/Dawn/Generated/CallbackInfo.swift
+++ b/Sources/Dawn/Generated/CallbackInfo.swift
@@ -117,6 +117,7 @@ public struct GPUCreateComputePipelineAsyncCallbackInfo: GPUStruct {
 				let unmanagedCallback = Unmanaged<AnyObject>.fromOpaque(userdata1!)
 				let callback = unmanagedCallback.takeUnretainedValue() as! GPUCreateComputePipelineAsyncCallback
 				callback(status, pipeline, message)
+				pipeline?.release()
 
 			}
 			var wgpuStruct = WGPUCreateComputePipelineAsyncCallbackInfo(
@@ -162,6 +163,7 @@ public struct GPUCreateRenderPipelineAsyncCallbackInfo: GPUStruct {
 				let unmanagedCallback = Unmanaged<AnyObject>.fromOpaque(userdata1!)
 				let callback = unmanagedCallback.takeUnretainedValue() as! GPUCreateRenderPipelineAsyncCallback
 				callback(status, pipeline, message)
+				pipeline?.release()
 
 			}
 			var wgpuStruct = WGPUCreateRenderPipelineAsyncCallbackInfo(
@@ -384,6 +386,7 @@ public struct GPURequestAdapterCallbackInfo: GPUStruct {
 				let unmanagedCallback = Unmanaged<AnyObject>.fromOpaque(userdata1!)
 				let callback = unmanagedCallback.takeUnretainedValue() as! GPURequestAdapterCallback
 				callback(status, adapter, message)
+				adapter?.release()
 
 			}
 			var wgpuStruct = WGPURequestAdapterCallbackInfo(
@@ -429,6 +432,7 @@ public struct GPURequestDeviceCallbackInfo: GPUStruct {
 				let unmanagedCallback = Unmanaged<AnyObject>.fromOpaque(userdata1!)
 				let callback = unmanagedCallback.takeUnretainedValue() as! GPURequestDeviceCallback
 				callback(status, device, message)
+				device?.release()
 
 			}
 			var wgpuStruct = WGPURequestDeviceCallbackInfo(
@@ -474,6 +478,7 @@ public struct GPUUncapturedErrorCallbackInfo: GPUStruct {
 				let unmanagedCallback = Unmanaged<AnyObject>.fromOpaque(userdata1!)
 				let callback = unmanagedCallback.takeUnretainedValue() as! GPUUncapturedErrorCallback
 				callback(device, type, message)
+
 				unmanagedCallback.release()
 			}
 			var wgpuStruct = WGPUUncapturedErrorCallbackInfo(

--- a/Sources/GenerateDawnBindings/DawnCallbackFunction+Wrappers.swift
+++ b/Sources/GenerateDawnBindings/DawnCallbackFunction+Wrappers.swift
@@ -53,6 +53,11 @@ extension DawnCallbackFunction {
 			"_ userdata1: UnsafeMutableRawPointer?"
 			"_ userdata2: UnsafeMutableRawPointer?"
 		}
+		let objectReleaseStatements = args.compactMap { arg -> String? in
+			guard arg.optional && arg.annotation == nil else { return nil }
+			guard let entity = data.data[arg.type], case .object = entity else { return nil }
+			return "\(arg.name.camelCase)?.release()"
+		}.joined(separator: "\n\t\t\t\t")
 		return """
 			{ (\(argumentSignature)) in
 					\(raw: wrapArgs(args, data: data).map { $0.formatted().description }.joined(separator: "\n"))
@@ -60,6 +65,7 @@ extension DawnCallbackFunction {
 					let unmanagedCallback = Unmanaged<AnyObject>.fromOpaque(userdata1!)
 					let callback = unmanagedCallback.takeUnretainedValue() as! GPU\(raw: type.CamelCase)
 					callback(\(raw: args.map { "\($0.name.camelCase)" }.joined(separator: ", ")))
+					\(raw: objectReleaseStatements)
 					\(raw: multipleUseCallbacks.contains(type) ? "unmanagedCallback.release()" : "")
 			}
 			"""


### PR DESCRIPTION
Contributed by Adam Altman.

Swan APIs that create objects asynchronously with callbacks create those objects with a reference count of 1 as far as Dawn is concerned. Swift, however, doesn’t see this reference count and will not release this initial reference. To fix this, generated code needs to release such objects after they have been given to the client through their callback.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
