### PR TITLE
Fix Dawn nightly build: bump hardcoded Apple SDK versions

### DIFF
--- a/Dawn/ci_targets.py
+++ b/Dawn/ci_targets.py
@@ -56,7 +56,7 @@ def ci_target(target: str, archs: list[str], config: str = "release") -> TargetC
             return TargetConfig(
                 os=OS.MACOS,
                 arch=arch_enums,
-                sdk="macosx15.5",
+                sdk="macosx26.5",
                 deployment_target="14.0",
                 config=config,
             )
@@ -64,7 +64,7 @@ def ci_target(target: str, archs: list[str], config: str = "release") -> TargetC
             return TargetConfig(
                 os=OS.IPHONE,
                 arch=arch_enums,
-                sdk="iphoneos18.5",
+                sdk="iphoneos26.5",
                 deployment_target="18.0",
                 config=config,
             )
@@ -72,7 +72,7 @@ def ci_target(target: str, archs: list[str], config: str = "release") -> TargetC
             return TargetConfig(
                 os=OS.IPHONE,
                 arch=arch_enums,
-                sdk="iphonesimulator18.5",
+                sdk="iphonesimulator26.5",
                 deployment_target="18.0",
                 config=config,
             )


### PR DESCRIPTION
## Summary
- The nightly Dawn Debug Build workflow (run 28735486408) has been failing with `SDK iphoneos18.5 not found` since GitHub's `macos-latest` runner migrated to the `macos-26-arm64` image, which no longer ships the old SDK versions hardcoded in `Dawn/ci_targets.py`.
- Bumps `macosx15.5` → `macosx26.5`, `iphoneos18.5` → `iphoneos26.5`, and `iphonesimulator18.5` → `iphonesimulator26.5` to match what the current runner image's default Xcode (26.5) actually provides.
- The `ipados` case was left untouched — there's no `ipados*` SDK on the runner (iPadOS builds always used the `iphoneos` SDK), and it isn't part of the nightly matrix, so it's outside this fix's scope.

## Test plan
- [ ] Confirm the nightly Dawn Debug Build workflow succeeds on `macos-latest` runners after merge